### PR TITLE
fix: populate PYTORCH_ROCM_ARCH if empty

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = python-torchaudio-rocm
 	pkgdesc = Data manipulation and transformation for audio signal processing, powered by PyTorch (ROCm Support)
 	pkgver = 2.0.2
-	pkgrel = 3
+	pkgrel = 4
 	url = https://github.com/pytorch/audio
 	arch = x86_64
 	arch = i686

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=python-torchaudio-rocm
 _pkgname=audio
 pkgver=2.0.2
 _sox_ver=14.4.2
-pkgrel=3
+pkgrel=4
 pkgdesc="Data manipulation and transformation for audio signal processing, powered by PyTorch (ROCm Support)"
 arch=('x86_64' 'i686')
 url="https://github.com/pytorch/audio"
@@ -56,6 +56,13 @@ prepare() {
 
 build() {
   cd "$srcdir/${_pkgname}"
+
+  # populate build architecture list if not set from arch:python-pytorch-rocm@2.0.1#7
+  if test -n "$PYTORCH_ROCM_ARCH"; then
+    export PYTORCH_ROCM_ARCH="$PYTORCH_ROCM_ARCH"
+  else
+    export PYTORCH_ROCM_ARCH="gfx803;gfx900;gfx906;gfx908;gfx90a;gfx1030;gfx1100;gfx1101;gfx1102"
+  fi
 
   # hardcode ROCM_PATH and HIP_ROOT_DIR to /opt/rocm (from arch:python-pytorch-rocm@2.0.1#7)
   export ROCM_PATH=/opt/rocm


### PR DESCRIPTION
Analogous to the [approach](https://github.com/rocm-arch/python-torchvision-rocm/blob/54e619fb5b5d33a74c4fbb386ee6e0bfdea1ac3f/PKGBUILD#L65-L70) in sister project `python-torchvision-rocm`, populate `PYTORCH_ROCM_ARCH` if empty. This environment variable will be checked when building `pytorch/audio`. Failure to provide will lead to the error:

    CMake Error at /usr/lib/cmake/Caffe2/public/utils.cmake:370 (message):
       Could not detect ROCm arch for GPUs on machine. Result: 'No such file or directory'